### PR TITLE
Remove rust from build of DomD & DomU

### DIFF
--- a/meta-xt-domu/recipes-gnome/gtk+/gtk+3_%.bbappend
+++ b/meta-xt-domu/recipes-gnome/gtk+/gtk+3_%.bbappend
@@ -1,0 +1,4 @@
+# Avoid installation of the redundant 'adwaita-icon-theme' package.
+# It is causing build of the rust, which we want to avoid, as it takes a lot of time.
+RRECOMMENDS:${PN}:remove = " adwaita-icon-theme-symbolic"
+RRECOMMENDS:${PN}:libc-glibc:remove = " adwaita-icon-theme-symbolic"

--- a/meta-xt-domu/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/meta-xt-domu/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,3 @@
+# Removing dependency to the librsvg, as it is using rust.
+# And usage of rust is increasing the build time a lot.
+PACKAGECONFIG:remove = " rsvg"

--- a/meta-xt-driver-domain/recipes-gnome/gtk+/gtk+3_%.bbappend
+++ b/meta-xt-driver-domain/recipes-gnome/gtk+/gtk+3_%.bbappend
@@ -1,0 +1,4 @@
+# Avoid installation of the redundant 'adwaita-icon-theme' package.
+# It is causing build of the rust, which we want to avoid, as it takes a lot of time.
+RRECOMMENDS:${PN}:remove = " adwaita-icon-theme-symbolic"
+RRECOMMENDS:${PN}:libc-glibc:remove = " adwaita-icon-theme-symbolic"

--- a/meta-xt-driver-domain/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/meta-xt-driver-domain/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,3 @@
+# Removing dependency to the librsvg, as it is using rust.
+# And usage of rust is increasing the build time a lot.
+PACKAGECONFIG:remove = " rsvg"


### PR DESCRIPTION
After switching to the new Renesas BSP 5.9.0 and Yocto Kirkstone we've identified several minor dependencies, including the 'rust' package into the DomD and DomU build. That caused a significant increase in the build-time. Due to the insignificance of the identified dependencies, we've decided to cut them out.

Those are:
- adwaita-icon-theme, used by the 'gtk+3' package
- librsvg, used by the 'gstreamer1.0-plugins-bad' package

Operability of the fix was confirmed using the bitbake dependency graph.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>