### PR TITLE
Turn off displbe and sndbe services

### DIFF
--- a/meta-xt-control-domain/recipes-guest/domu/files/domu.service
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=DomU
-Requires=backend-ready@displbe.service backend-ready@sndbe.service
-After=backend-ready@displbe.service backend-ready@sndbe.service
 
 [Service]
 Type=oneshot

--- a/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -4,7 +4,6 @@ IMAGE_INSTALL:append = " \
     xen-tools-scripts-network \
     xen-tools-scripts-block \
     xen-tools-xenstore \
-    displbe \
     xen-network \
     dnsmasq \
     block \


### PR DESCRIPTION
For virtio-based product, there is no need in the displbe.service and sndbe.service systemd units. They are redundant in our context.

This patch turns off the compilation and installation of those services.

Also, it excludes them as a dependency for the other systemd services.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>