### PR TITLE
u-boot-android.bb: Fix the build of the u-boot-android

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android.bb
@@ -1,7 +1,7 @@
 require recipes-bsp/u-boot/u-boot-common.inc
 require recipes-bsp/u-boot/u-boot.inc
 
-UBOOT_CONFIG[doma] = "xenguest:arm64_android_defconfig"
+UBOOT_CONFIG[doma] = "xenguest_arm64_android_defconfig"
 UBOOT_CONFIG = "doma"
 
 SRCREV = "${AUTOREV}"
@@ -9,6 +9,8 @@ UBOOT_SOURCE ??= "git://github.com/xen-troops/u-boot.git;protocol=https;branch=a
 SRC_URI = "\
     ${UBOOT_SOURCE} \
 "
+
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 
 FILES:${PN} = " \
     ${libdir}/xen/boot/u-boot-doma \


### PR DESCRIPTION
After switching to the Renesas BSP 5.9.0 the u-boot license checksum, which is specified in the 'meta-renesas' layer stopped to fit the license file in the xen-troops->u-boot repository on the Github.

This patch adjusts the used u-boot checksum.

Besides that, the patch fixes the name of the doma UBOOT_CONFIG variable, which was accidentally changed in the wrong way, during the adaptation to the new Yocto syntax.

Both issues were causing a build failure of the Dom0, when built with ENABLE_ANDROID parameter.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>