### PR TITLE
domu.service: Add dependency on domd.service

### DIFF
--- a/meta-xt-control-domain/recipes-guest/domu/files/domu.service
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu.service
@@ -1,6 +1,12 @@
 [Unit]
 Description=DomU
 
+# NOTE 1
+# DomU should be started after DomD, as there are parameters across
+# the system, which rely on DomD having the Xen domain id equal to '1'
+Requires=domd.service
+After=domd.service
+
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/xl create /etc/xen/domu.cfg


### PR DESCRIPTION
After switching off the 'displbe' and 'sndbe' services, it turned out that DomU may start before DomD. That is causing issues, as some parameters are strictly relying on DomD having the Xen domain id equal to '1'.

In order to achieve the correct starting order of the domains, we've added dependency of domu.service on domd.service.